### PR TITLE
Add dependencies for Python support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     git \
     sudo \
+    python3 \
+    python3-serial \
     && rm -rf /var/lib/apt/lists/*
 
 # Arduino CLI installieren


### PR DESCRIPTION
Python3 and Python3-serial (pyserial) needed for arduino-cli build actions.